### PR TITLE
Add Dockerfile for building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM minizinc/mznc2026:latest
+
+# Install fzn_picat_sat binary
+COPY --chmod=0755 ./fzn_picat_sat /picat_sat/bin/fzn_picat_sat
+# Install redefinitions library
+COPY ./mznlib /picat_sat/share/minizinc/picat
+
+# Copy and configure the solver configuration file
+COPY ./picat.msc.in /picat_sat/share/minizinc/solvers/picat.msc
+
+RUN sed -i 's|MZNLIB_LOCATION|../picat|' /picat_sat/share/minizinc/solvers/picat.msc && \
+    sed -i 's|EXECUTABLE_LOCATION|../../../bin/fzn_picat_sat|' /picat_sat/share/minizinc/solvers/picat.msc && \
+    echo '{"mzn_solver_path": ["/picat_sat/share/minizinc/solvers"], "tagDefaults": [["", "org.picat-lang.picat"]]}' > $HOME/.minizinc/Preferences.json


### PR DESCRIPTION
Adds a Dockerfile for creating an image to be submitted to the MiniZinc Challenge.

To build and push the image, run:

```sh
docker build -t <docker_hub_username>/fzn_picat_sat:latest .
# If you haven't logged in yet, run docker login before pushing
docker push <docker_hub_username>/fzn_picat_sat:latest
```

You can sanity check that the image is working starting a container and getting an interactive terminal for it:
```sh
docker run --rm -it <docker_hub_username>/fzn_picat_sat:latest
> minizinc test.mzn 2.dzn
```

And you should see the solver running correctly.

If you need to debug something, you can mount a folder `/path/to/models` from your filesystem to appear as `/models` inside the container:
```sh
docker run --rm -it -v /path/to/models:/models <docker_hub_username>/fzn_picat_sat:latest
> minizinc /models/foo.mzn /models/bar.mzn
```

For future Challenges, you just have to update the first line in the `Dockerfile`:
```
FROM minizinc/mznc<year>:latest
```
to match the Challenge year and run the build/push commands again.